### PR TITLE
SDLC etiquette: How-We-Ship block + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default approver for this repo. See varrdinc/_VARRD_ docs/SDLC.md §3.
+* @augiemazza

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# CLAUDE.md — varrd
+
+## ⭐ How We Ship — SDLC etiquette (READ BEFORE ANY COMMIT)
+
+> Canonical rules: `docs/SDLC.md` in `varrdinc/_VARRD_`. The non-negotiables:
+>
+> - **Never push to `main`** (org ruleset blocks it). Branch (`claude/<desc>`) → PR →
+>   review → squash-merge. Default approver: **@augiemazza** (see CODEOWNERS).
+> - **Never `git add -A`.** Stage ONLY files you changed, by name.
+> - PR body = **root cause · fix · risk · how tested**.
+> - One logical change per PR. Branches auto-delete on merge.
+> - Never force-push `main`, never `--no-verify`.
+> - **Never commit a secret** (key, token, password, .env). Secrets live in AWS SSM
+>   Parameter Store under `/varrd/*` — reference by name, fetch at runtime.
+> - Found gross/outdated code while working? Fix it in its OWN small PR — never smuggled.


### PR DESCRIPTION
Org-wide rollout of the SDLC standard (varrdinc/_VARRD_ docs/SDLC.md). Adds the How-We-Ship etiquette block to CLAUDE.md (prepended; existing content untouched) + CODEOWNERS (* @augiemazza). Docs only, zero runtime code.